### PR TITLE
Close hole in USI Life Support cycle

### DIFF
--- a/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Algae.cfg
+++ b/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Algae.cfg
@@ -139,7 +139,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport]
 		{
 			ResourceName = Fertilizer
 			Ratio =  0.0008
-			DumpExcess = true
+			DumpExcess = false
 		}
 	}
     

--- a/Sources/PlanetarySurfaceStructures/ModuleKPBSDependentLight.cs
+++ b/Sources/PlanetarySurfaceStructures/ModuleKPBSDependentLight.cs
@@ -228,7 +228,7 @@ namespace PlanetarySurfaceStructures
                 if ((dependent != null))
                 {
                     //set the animation to the beginning when the state is not "Deployed"
-                    if (dependent.animationTime < 0.9999f)
+                    if (dependent.animationTime < 0.999f)
                     {
                         //disable the GUI
                         Events["toggleAnimation"].guiActiveEditor = false;


### PR DESCRIPTION
Algae Farm would dump excessive Fertilizer creating a hole in which Supplies/Mulch can disappear from the USI Life Support cycle. Preventing the Fertilizer dump properly closes the cycle and allows for Supplies generation at cost of Ore and EC.