### PR TITLE
Add Core Heat mechanism to Planetary ISRU

### DIFF
--- a/GameData/PlanetaryBaseInc/BaseSystem/Parts/Resources/ISRU_g.cfg
+++ b/GameData/PlanetaryBaseInc/BaseSystem/Parts/Resources/ISRU_g.cfg
@@ -48,6 +48,11 @@ PART
     maxTemp = 2100
     fuelCrossFeed = True
     bulkheadProfiles = PlanetaryBase
+    
+    MODULE
+	{
+		name = ModuleOverheatDisplay
+	}
 
 	MODULE
 	{
@@ -55,8 +60,26 @@ PART
 		ConverterName = Lf+Ox
 		StartActionName = Start ISRU [Lf+Ox]
 		StopActionName = Stop ISRU [Lf+Ox]	 
-		AutoShutdown = false
-		GeneratesHeat = false
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500	
+			key = 2000 50	
+			key = 4000 0
+		}				
+		GeneratesHeat = true
+		DefaultShutoffTemp = .8
+		ThermalEfficiency 
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0 
+		}
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -97,8 +120,26 @@ PART
 		ConverterName = Monoprop
 		StartActionName = Start ISRU [Monoprop]
 		StopActionName = Stop ISRU [Monoprop]
-		AutoShutdown = false
-		GeneratesHeat = false
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500	
+			key = 2000 50	
+			key = 4000 0
+		}				
+		GeneratesHeat = true
+		DefaultShutoffTemp = .8
+		ThermalEfficiency 
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0 
+		}
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -131,8 +172,26 @@ PART
 		ConverterName = LiquidFuel
 		StartActionName = Start ISRU [LqdFuel]
 		StopActionName = Stop ISRU [LqdFuel]
-		AutoShutdown = false
-		GeneratesHeat = false
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500	
+			key = 2000 50	
+			key = 4000 0
+		}				
+		GeneratesHeat = true
+		DefaultShutoffTemp = .8
+		ThermalEfficiency 
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0 
+		}
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -167,8 +226,26 @@ PART
 		ConverterName = Oxidizer
 		StartActionName = Start ISRU [Ox]
 		StopActionName = Stop ISRU [Ox]
-		AutoShutdown = false
-		GeneratesHeat = false
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 750 50000
+			key = 1000 10000
+			key = 1250 500	
+			key = 2000 50	
+			key = 4000 0
+		}				
+		GeneratesHeat = true
+		DefaultShutoffTemp = .8
+		ThermalEfficiency 
+		{
+			key = 0 0 0 0
+			key = 500 0.1 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.1 0 0
+			key = 3000 0 0 0 
+		}
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -203,6 +280,24 @@ PART
 		activeAnimationName = ISRU_work
 		moduleType = Converter
 		autoDeploy = true
+	}
+	
+	MODULE
+	{
+		name = ModuleCoreHeat
+		CoreTempGoal = 1000					//Internal temp goal - we don't transfer till we hit this point
+		CoreToPartRatio = 0.1				//Scale back cooling if the part is this % of core temp
+		CoreTempGoalAdjustment = 0			//Dynamic goal adjustment
+		CoreEnergyMultiplier = 0.1			//What percentage of our core energy do we transfer to the part
+		HeatRadiantMultiplier = 0.05		//If the core is hotter, how much heat radiates?
+		CoolingRadiantMultiplier = 0		//If the core is colder, how much radiates?
+		HeatTransferMultiplier = 0			//If the part is hotter, how much heat transfers in?
+		CoolantTransferMultiplier = 0.01	//If the part is colder, how much of our energy can we transfer?
+		radiatorCoolingFactor = 1			//How much energy we pull from core with an active radiator?  >= 1
+		radiatorHeatingFactor = 0.01		//How much energy we push to the active radiator
+		MaxCalculationWarp = 1000			//Based on how dramatic the changes are, this is the max rate of change
+		CoreShutdownTemp = 4000				//At what core temperature do we shut down all generators on this part?
+		MaxCoolant = 500					//Maximum amount of radiator capacity we can consume - 50 = 1 small
 	}
 
 }


### PR DESCRIPTION
Hi,

This changes the Planetary ISRU to use the same core heat/thermal efficiency system that the stock ISRU uses. I've tested the change, and it works just like I expected for a simple setup. I actually just pasted in the code from the stock ISRU's config file, so the heat generation specs are the same:

- 200 kW generated per converter module at 1000K (shown as "required cooling" in VAB)
- 500 kW of max usable cooling
- shuts down at 4000K, but the heat-generation curve falls off so sharply as temperature rises that it's actually not easy to get it that hot (radiative cooling eventually catches it, in simple cases)

My only caveat is that as I have it here, this part generates 100% of the heat but works at 80% the rate of the stock ISRU. Would it make sense to lower the heat generation a bit, for balance purposes? FWIW, this part + one planetary drill should require a total of 250kW cooling at peak efficiency, which is a convenient figure.

Anyway, let me know if this is helpful. I figured that I should actually learn to use GitHub and do this dang thing myself, instead of just pestering you on the KSP forums about it!

---Sargon