### PR TITLE
Fix CLS passability issues

### DIFF
--- a/GameData/PlanetaryBaseInc/ModSupport/Configs/CLS/KPBS_MM_CLS.cfg
+++ b/GameData/PlanetaryBaseInc/ModSupport/Configs/CLS/KPBS_MM_CLS.cfg
@@ -4,6 +4,7 @@
     {
         name = ModuleConnectedLivingSpace
         passable = true
+        impassablenodes = bottom
     }
 }
 @PART[KKAOSS_Automatic_Control_g]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
@@ -38,6 +39,7 @@
     {
         name = ModuleConnectedLivingSpace
         passable = true
+        impassablenodes = leg1 , leg2       
     }
 }
 @PART[KKAOSS_airlock_mid_g]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
@@ -45,8 +47,7 @@
     MODULE
     {
         name = ModuleConnectedLivingSpace
-        passable = true
-        
+        passable = true 
     }
 }
 @PART[KKAOSS_Service_g]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
@@ -148,7 +149,7 @@
         name = ModuleConnectedLivingSpace
         passable = true
         passableWhenSurfaceAttached = true 
-		surfaceAttachmentsPassable = true
+        surfaceAttachmentsPassable = true
     }
 }
 
@@ -159,17 +160,17 @@
         name = ModuleConnectedLivingSpace
         passable = true
         passableWhenSurfaceAttached = true 
-		surfaceAttachmentsPassable = true
+        surfaceAttachmentsPassable = true
     }
 }
 @PART[KKAOSS_gangway_2_adapter]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-	MODULE
-	{
+    MODULE
+    {
         name = ModuleConnectedLivingSpace
-		passable = true
-		impassablenodes = leg_1 , leg_2
-	}
+        passable = true
+        impassablenodes = leg_1 , leg_2
+    }
 }
 @PART[KKAOSS_gangway_2_1]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
@@ -292,5 +293,13 @@
         name = ModuleConnectedLivingSpace
         passable = true
         impassablenodes = front , back
+    }
+}
+@PART[KKAOSS_garage_adapter_g_2]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+{
+    MODULE
+    {
+        name = ModuleConnectedLivingSpace
+        passable = true
     }
 }


### PR DESCRIPTION
* Planetary Central Hub bottom node is no longer passable - it has no hatch, and other parts have equivalent nodes already marked the same.
* Garage Adapter is now passable - it clearly has hatches on both sides.
* Airlock (end version) now has leg1 and leg2 nodes marked as not passable.
* Convert tabs to spaces to make the file consistent.

Please note, however, that it looks like current version of CLS (1.2.3.0) seems not to process nodes defined in the `NODE{}` module. All of these nodes just inherit the passable trait. This applies to all parts that have some of their nodes defined in such way - airlock, adapter, engine, etc. The fix would be to either change the config to list all passable nodes explicitly via `passablenodes` instead of using `passable`, or actually fix it in CLS.