### PR TITLE
Improve support for Kerbalism default profile

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/Profiles/KPBS_MM_Kerbalism_Default.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/Profiles/KPBS_MM_Kerbalism_Default.cfg
@@ -347,12 +347,13 @@
 {
   !MODULE[ModuleKPBSConverter] {}
   !RESOURCE[ElectricCharge] {}
+  !MODULE[Reliability] {}
 
   MODULE
   {
     name = ProcessController
     resource = _FuelCell
-    title = Fuel cell
+    title = Fuel Cell
     capacity = 6
   }
 
@@ -374,14 +375,8 @@
 @PART[KKAOSS_LS_container_sabatier]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&ProfileDefault]
 {
     title = K&K Life Support Recycler
-
-    MODULE
-    {
-        name = ProcessController
-        resource = _WaterElectrolysis
-        title = Water electrolysis
-        capacity = 3
-    }
+	
+	!MODULE[Reliability] {}
 
     MODULE
     {
@@ -393,62 +388,10 @@
 
     MODULE
     {
-        name = ProcessController
-        resource = _Haber
-        title = Haber process
-        capacity = 3
-    }
-
-    MODULE
-    {
-        name = ProcessController
-        resource = _Anthraquinone
-        title = Anthraquinone process
-        capacity = 3
-    }
-
-    MODULE
-    {
-        name = ProcessController
-        resource = _HydrazineProduction
-        title = Hydrazine production
-        capacity = 3
-    }
-
-    MODULE
-    {
-        name = ProcessController
-        resource = _MRE
-        title = MRE
-        capacity = 3
-    }
-
-    MODULE
-    {
-        name = ProcessController
-        resource = _SOE
-        title = SOE
-        capacity = 3
-    }
-
-    MODULE
-    {
         name = Configure
         title = Chemical Plant
         slots = 1
-
-        SETUP
-        {
-            name = Water Electrolysis
-
-            MODULE
-            {
-                type = ProcessController
-                id_field = resource
-                id_value = _WaterElectrolysis
-            }
-        }
-
+		
         SETUP
         {
             name = Sabatier Process
@@ -458,72 +401,6 @@
                 type = ProcessController
                 id_field = resource
                 id_value = _Sabatier
-            }
-        }
-
-        SETUP
-        {
-            name = Haber Process
-
-            MODULE
-            {
-                type = ProcessController
-                id_field = resource
-                id_value = _Haber
-            }
-        }
-
-        SETUP
-        {
-            name = Anthraquinone Process
-            tech = advScienceTech
-
-            MODULE
-            {
-                type = ProcessController
-                id_field = resource
-                id_value = _Anthraquinone
-            }
-        }
-
-        SETUP
-        {
-            name = Hydrazine Production
-            tech = advScienceTech
-
-            MODULE
-            {
-                type = ProcessController
-                id_field = resource
-                id_value = _HydrazineProduction
-            }
-        }
-
-        SETUP
-        {
-            name = Solid Oxide Electrolysis
-            desc = Convert <b>CarbonDioxide</b> into <b>Oxygen</b>, using vast amounts of <b>ElectricCharge</b> in the process.
-            tech = experimentalScience
-
-            MODULE
-            {
-                type = ProcessController
-                id_field = resource
-                id_value = _SOE
-            }
-        }
-
-        SETUP
-        {
-            name = Molten Regolith Electrolysis
-            desc = Extract <b>Oxygen</b> out of <b>Ore</b>.
-            tech = experimentalScience
-
-            MODULE
-            {
-                type = ProcessController
-                id_field = resource
-                id_value = _MRE
             }
         }
     }
@@ -548,6 +425,8 @@
 {
     @description = A multi purpose airfilter. It is able to gather multiples resources like oxygen or nitrogen from the atmosphere
 	@TechRequired = largeElectrics
+	
+	!MODULE[Reliability] {}
 
     MODULE
     {
@@ -643,3 +522,295 @@
     }
 }
 
+@PART[KKAOSS_drill]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&ProfileDefault]
+{
+    !MODULE[ModuleResourceHarvester] {}
+    !MODULE[ModuleOverheatDisplay] {}
+    !MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleAsteroidDrill] {}
+	!MODULE[Reliability] {}
+  
+    MODULE
+    {
+      name = Harvester
+      title = Ore Extraction
+      drill = ImpactTransform
+      type = 0
+      resource = Ore
+      min_abundance = 0.05
+      rate = 0.0125
+      ec_rate = 5.0
+    }
+  
+    MODULE
+    {
+      name = Configure
+      title = Drill
+      slots = 1
+    
+      SETUP
+      {
+        name = Ore Extraction
+        desc = Extract <b>Ore</b> from the surface.
+       
+        MODULE
+        {
+          type = Harvester
+          id_field = resource
+          id_value = Ore
+        }
+       
+        RESOURCE
+        {
+          name = Ore
+          amount = 0
+          maxAmount = 50
+        }
+      }
+    }
+  
+    MODULE:NEEDS[FeatureReliability]
+    {
+      name = Reliability
+      type = Harvester
+      title = Harvester
+      repair = Engineer
+      mtbf = 72576000 // 8y
+      extra_cost = 1.0
+      extra_mass = 0.2
+    }
+}
+
+@PART[KKAOSS_LS_drill_water]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&ProfileDefault]
+{
+    !MODULE[ModuleResourceHarvester] {}
+    !MODULE[ModuleOverheatDisplay] {}
+    !MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleAsteroidDrill] {}
+	!MODULE[Reliability] {}
+  
+    MODULE
+    {
+      name = Harvester
+      title = Water Extraction
+      drill = ImpactTransform
+      type = 0
+      resource = Water
+      min_abundance = 0.01
+      rate = 0.0025
+      ec_rate = 5.0
+    }
+    
+    MODULE
+    {
+      name = Configure
+      title = Drill
+      slots = 1
+  
+      SETUP
+      {
+        name = Water Extraction
+        desc = Extract <b>Water</b> from the surface.
+  
+        MODULE
+        {
+          type = Harvester
+          id_field = resource
+          id_value = Water
+        }
+  
+        RESOURCE
+        {
+          name = Water
+          amount = 0
+          maxAmount = 50
+        }
+      }
+    }
+	
+	MODULE:NEEDS[FeatureReliability]
+    {
+	  name = Reliability
+	  type = Harvester
+	  title = Harvester
+	  repair = Engineer
+	  mtbf = 72576000 // 8y
+	  extra_cost = 1.0
+	  extra_mass = 0.2
+    }
+}
+
+// ============================================================================
+// ISRU
+// ============================================================================
+@PART[KKAOSS_ISRU_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&ProfileDefault]
+{
+    !MODULE[ModuleResourceConverter],* {}
+    !MODULE[ModuleOverheatDisplay] {}
+    !MODULE[ModuleCoreHeat] {}
+	!MODULE[Reliability] {}
+	
+    MODULE
+    {
+      name = ProcessController
+      resource = _WaterElectrolysis
+      title = Water electrolysis
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = ProcessController
+      resource = _Sabatier
+      title = Sabatier process
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = ProcessController
+      resource = _Haber
+      title = Haber process
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = ProcessController
+      resource = _Anthraquinone
+      title = Anthraquinone process
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = ProcessController
+      resource = _HydrazineProduction
+      title = Hydrazine production
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = ProcessController
+      resource = _MRE
+      title = MRE
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = ProcessController
+      resource = _SOE
+      title = SOE
+      capacity = 5
+    }
+    
+    MODULE
+    {
+      name = Configure
+      title = Chemical Plant
+      slots = 2
+    
+      SETUP
+      {
+        name = Water Electrolysis
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _WaterElectrolysis
+        }
+      }
+    
+      SETUP
+      {
+        name = Sabatier Process
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _Sabatier
+        }
+      }
+    
+      SETUP
+      {
+        name = Haber Process
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _Haber
+        }
+      }
+    
+      SETUP
+      {
+        name = Anthraquinone Process
+        tech = advScienceTech
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _Anthraquinone
+        }
+      }
+    
+      SETUP
+      {
+        name = Hydrazine Production
+        tech = advScienceTech
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _HydrazineProduction
+        }
+      }
+    
+      SETUP
+      {
+        name = Solid Oxide Electrolysis
+        desc = Convert <b>CarbonDioxide</b> into <b>Oxygen</b>, using vast amounts of <b>ElectricCharge</b> in the process.
+        tech = experimentalScience
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _SOE
+        }
+      }
+    
+      SETUP
+      {
+        name = Molten Regolith Electrolysis
+        desc = Extract <b>Oxygen</b> out of <b>Ore</b>.
+        tech = experimentalScience
+    
+        MODULE
+        {
+          type = ProcessController
+          id_field = resource
+          id_value = _MRE
+        }
+      }
+    }
+    
+    MODULE:NEEDS[FeatureReliability]
+    {
+      name = Reliability
+      type = ProcessController
+      title = Chemical Plant
+      repair = Engineer
+      mtbf = 72576000 // 8y
+      extra_cost = 1.0
+      extra_mass = 0.2
+    }
+}


### PR DESCRIPTION
* switch K&K Planetary ISRU to Kerbalism Chemical Plant to match changes to stock ISRUs. Stats should match the 2.5m stock ISRU.
* switch K&K Life Support Recycler to Kerbalism Chemical Plant and remove all reactions besides Sabatier. This brings the function of the part in line with the current description.
* switch K&K Inline Drill to Kerbalism Harvester module
* switch K&K Inline Water Drill to Kerbalism Harvester module
* remove any Reliability modules added by "global" patches