### PR TITLE
USI-LS Rebalance

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_USI_LS.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_USI_LS.cfg
@@ -90,7 +90,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.25
+			Ratio = 0.225
 		}
 	}
 
@@ -151,7 +151,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 4.0
+			Ratio = 0.40
 		}
 	}
     RESOURCE
@@ -193,7 +193,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.7
+			Ratio = 0.27
 		}
 	}
     RESOURCE
@@ -233,7 +233,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.875
+			Ratio = 0.0875
 		}
 	}
 	MODULE
@@ -268,7 +268,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ration = 0.075
+			Ration = 0.0075
 		}
 	}
 	MODULE

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_USI_LS.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_USI_LS.cfg
@@ -2,7 +2,7 @@
 @PART[KKAOSS_Greenhouse_g]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
 {
 	@tags = cck-lifesupport
-    
+
     MODULE
 	{
 		name = PlanetaryGreenhouse
@@ -11,67 +11,49 @@
 		StopActionName = Stop Farming
 		AutoShutdown = false
 		GeneratesHeat = false
-		 
+
 		INPUT_RESOURCE
 		{
 			ResourceName = Mulch
-			Ratio =  0.0045
+			Ratio =  0.0012
 		}
         INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.0006
+			Ratio =  0.00012
 
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Supplies
-			Ratio = 0.0051
+			Ratio = 0.00132
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 20
+			Ratio = 2.64
 		}
 	}
-	
-	
-	MODULE
-	{
-		name = ModuleLifeSupportRecycler
-		CrewCapacity = 4
-		RecyclePercent = .35
-		ConverterName = Life Support
-		tag = Life Support
-		StartActionName = Start Life Support
-		StopActionName = Stop Life Support
 
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1
-		}
-		
-	}
-    
-    
+
+
     MODULE
 	{
     	name = ModuleHabitation
 		BaseKerbalMonths = 0
-		CrewCapacity = 2
-		BaseHabMultiplier = 1.3
+		CrewCapacity = 3
+		BaseHabMultiplier = 1
 		ConverterName = Habitat
 		StartActionName = Start Habitat
-		StopActionName = Stop Habitat		
+		StopActionName = Stop Habitat
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.525
+			Ratio = 0.75
 		}
-	}    
-    
+	}
+
     RESOURCE
 	{
 		name = Mulch
@@ -94,74 +76,34 @@
 
 @PART[KKAOSS_Central_Hub]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
 {
-    RESOURCE
-	{
-		name = Mulch
-		amount = 0
-		maxAmount = 150
-	}
-	RESOURCE
-	{
-		name = Supplies
-		amount = 300
-		maxAmount = 300
-	}
-    RESOURCE
-	{
-		name = Water
-		amount = 100
-		maxAmount = 100
-	}
-    
+    @tags = cck-lifesupport
+
     MODULE
 	{
         name = ModuleHabitation
-		BaseKerbalMonths = 60
+		BaseKerbalMonths = 0
 		CrewCapacity = 6
-		BaseHabMultiplier = 0
+		BaseHabMultiplier = 1.5
 		ConverterName = Habitat
 		StartActionName = Start Habitat
-		StopActionName = Stop Habitat		
+		StopActionName = Stop Habitat
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.925
+			Ratio = 2.25
 		}
 	}
-    RESOURCE
-    {
-        name = ReplacementParts
-        amount = 3500
-        maxAmount = 3500
-    }
+
 	MODULE
 	{
 		name = USI_ModuleFieldRepair
 	}
-    
+
     MODULE
 	{
 		name = ModuleLifeSupportRecycler
-		CrewCapacity = 8
-		RecyclePercent = .70
-		ConverterName = Life Support
-		tag = Life Support
-		StartActionName = Start Life Support
-		StopActionName = Stop Life Support
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 5.0
-		}
-
-	}
-    
-    MODULE
-	{
-		name = ModuleLifeSupportRecycler
-		CrewCapacity = 8
-		RecyclePercent = .90
+		CrewCapacity = 1
+		RecyclePercent = 0.925
 		ConverterName = Water Purifier
 		tag = Life Support
 		StartActionName = Start Water Purifier
@@ -170,12 +112,12 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 15.0
+			Ratio = 19.25
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio = 0.005
+			Ratio = 0.0085
 		}
 	}
 }
@@ -202,14 +144,14 @@
 		StartActionName = Start Habitat
 		StopActionName = Stop Habitat
 
-		BaseKerbalMonths = 30.0
-		CrewCapacity = 4
-		BaseHabMultiplier = 1.0
+		BaseKerbalMonths = 15.0
+		CrewCapacity = 5
+		BaseHabMultiplier = 0.2
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.7
+			Ratio = 4.0
 		}
 	}
     RESOURCE
@@ -221,7 +163,7 @@
 	MODULE
 	{
 		name = USI_ModuleFieldRepair
-	}  
+	}
 }
 @PART[KKAOSS_Habitat_MK1_g]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
 {
@@ -244,14 +186,14 @@
 		StartActionName = Start Habitat
 		StopActionName = Stop Habitat
 
-		BaseKerbalMonths = 20.0
-		CrewCapacity = 3
-		BaseHabMultiplier = 0
+		BaseKerbalMonths = 10.0
+		CrewCapacity = 4
+		BaseHabMultiplier = 0.2
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.45
+			Ratio = 2.7
 		}
 	}
     RESOURCE
@@ -271,27 +213,27 @@
 	{
 		name = ModuleLifeSupport
 	}
-	
+
     RESOURCE
     {
         name = ReplacementParts
         amount = 100
         maxAmount = 100
     }
-	
-    	MODULE 
+
+    	MODULE
 	{
 		name = ModuleHabitation
 		BaseKerbalMonths = 0
 		CrewCapacity = 2
-		BaseHabMultiplier = 2.0
+		BaseHabMultiplier = 1.75
 		ConverterName = Habitat
 		StartActionName = Start Habitat
-		StopActionName = Stop Habitat		
+		StopActionName = Stop Habitat
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.09
+			Ratio = 0.875
 		}
 	}
 	MODULE
@@ -306,39 +248,31 @@
 	{
 		name = ModuleLifeSupport
 	}
-	
+
     RESOURCE
     {
         name = ReplacementParts
         amount = 200
         maxAmount = 200
     }
-	
+
     MODULE
 	{
 		name = ModuleHabitation
 		KerbalMonths = 0
-		HabMultiplier = 1.25
+		CrewCapacity = 3
+		HabMultiplier = 0.1
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ration = 0.075
+		}
 	}
 	MODULE
 	{
 		name = USI_ModuleFieldRepair
-	}
-    
-    MODULE
-	{
-		name = ModuleLifeSupportRecycler
-		CrewCapacity = 5
-		RecyclePercent = .5
-		ConverterName = Life Support
-		tag = Life Support
-		StartActionName = Start Life Support
-		StopActionName = Stop Life Support
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1.2
-		}
 	}
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Algae.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Algae.cfg
@@ -44,7 +44,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport]
     angularDrag = 2
     crashTolerance = 15
     maxTemp = 2000 // = 3000
-    
+
 }
 //------------------COMMUNITY TECHTREE-------------------------
 @PART[KKAOSS_LS_container_algae]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
@@ -59,7 +59,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport]
     MODULE
 	{
 		name = ModuleKPBSConverter
-		ConverterName = Algae Farm 
+		ConverterName = Algae Farm
 		tag = Algae Farm
 		StartActionName = Start cultivation
         StopActionName = Stop cultivation
@@ -86,7 +86,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport]
 			DumpExcess = true
 		}
 	}
-    
+
     RESOURCE
 	{
 		name = Fertilizer
@@ -97,25 +97,58 @@ PART:NEEDS[TacLifeSupport|USILifeSupport]
 //------------------USI LS CONFIG--------------------
 @PART[KKAOSS_LS_container_algae]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
 {
-    @description = A small algae form to produce fertilizer. This can then be used to increase the performance of the greenhouse. Don't eat the fertilizer!
+    @description = A small algae form to produce fertilizer. This can then be used to increase the performance of the greenhouse. Don't eat the fertilizer!  Now with added operational modes from UberDyne Astronautics - These you can eat.  (Though there is still discussion on whether you'd want to.)
 
     MODULE
 	{
-		name = ModuleKPBSConverter
-		ConverterName = Algae Farm 
-		tag = Algae Farm
+		name = ModuleResourceConverter_USI
+		ConverterName = Algae Farm - Dry
+		tag = Algae Farm - Dry
 		StartActionName = Start cultivation
         StopActionName = Stop cultivation
+        UseSpecialistBonus = false      // This is an automated part.
+
 
 		INPUT_RESOURCE
 		{
 			ResourceName = Mulch
-			Ratio =  0.00075
+			Ratio =  0.0003
 		}
         INPUT_RESOURCE
 		{
 			ResourceName = Ore
-			Ratio =  0.002
+			Ratio =  0.0008
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.42
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00032
+			DumpExcess = false
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Algae Farm - Wet
+		tag = Algae Farm - Wet
+		StartActionName = Start cultivation
+        StopActionName = Stop cultivation
+        UseSpecialistBonus = false      // This is an automated part.
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio =  0.005
+		}
+        INPUT_RESOURCE
+		{
+			ResourceName = Ore
+			Ratio =  0.025
 		}
 		INPUT_RESOURCE
 		{
@@ -125,11 +158,98 @@ PART:NEEDS[TacLifeSupport|USILifeSupport]
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.0008
+			Ratio =  0.0001
 			DumpExcess = false
 		}
+		OUTPUT_RESOURCE
+		{
+		    ResourceName = Mulch
+		    Ratio = 0.00375
+		    DumpExcess = true
+		}
+    }
+
+    MODULE:NEEDS[UDASoylent]
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Green Soylent
+		tag = Green Soylent
+		StartActionName = Start Soylent Green
+		StopActionName = Stop Soylent Green
+
+		INPUT_RESOURCE
+		{
+			name = ElectricCharge
+			ResourceName = ElectricCharge
+			Ratio = #$@UDA_SOYLENT_CFG/ElectricChargeRatioUSILS$
+		}
+		INPUT_RESOURCE
+		{
+			name = SterileOrganicSlurry
+			ResourceName = SterileOrganicSlurry
+			Ratio = #$@UDA_SOYLENT_CFG/SterileOrganicSlurryRatioUSILS$
+		}
+		INPUT_RESOURCE
+		{
+			name = SoylentStarter
+			ResourceName = SoylentStarter
+			Ratio = #$@UDA_SOYLENT_CFG/SoylentStarterRatioUSILS$
+		}
+		OUTPUT_RESOURCE
+		{
+			name = Supplies
+			ResourceName = Supplies
+			Ratio = #$@UDA_SOYLENT_CFG/SuppliesRatioUSILS$
+			DumpExcess = False
+		}
 	}
-    
+	MODULE:NEEDS[UDASoylent]
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Red Soylent
+		tag = Red Soylent
+		StartActionName = Start Soylent Red
+		StopActionName = Stop Soylent Red
+
+		INPUT_RESOURCE
+		{
+			name = ElectricCharge
+			ResourceName = ElectricCharge
+			Ratio = #$@UDA_SOYLENT_CFG/ElectricChargeRatioUSILS$
+		}
+		INPUT_RESOURCE
+		{
+			name = SterileOrganicSlurry
+			ResourceName = SterileOrganicSlurry
+			Ratio = #$@UDA_SOYLENT_CFG/SterileOrganicSlurryRatioUSILS$
+			@Ratio *= 11
+		}
+		INPUT_RESOURCE
+		{
+			name = SoylentStarter
+			ResourceName = SoylentStarter
+			Ratio = #$@UDA_SOYLENT_CFG/SoylentStarterRatioUSILS$
+			@Ratio *= 11
+		}
+		OUTPUT_RESOURCE
+		{
+			name = Supplies
+			ResourceName = Supplies
+			Ratio = #$@UDA_SOYLENT_CFG/SuppliesRatioUSILS$
+			@Ratio *= 11
+			DumpExcess = False
+		}
+	}
+
+
+	MODULE
+	{
+		name = ModuleSwappableConverter
+		ResourceCosts = ElectricCharge,10
+		bayName = Converter
+		typeName = Filter
+	}
+
     RESOURCE
 	{
 		name = Mulch

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Greenhouse.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Greenhouse.cfg
@@ -44,7 +44,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
     angularDrag = 2
     crashTolerance = 15
     maxTemp = 2000 // = 3000
-    
+
     MODULE
 	{
 		name = ModuleScienceExperiment
@@ -63,7 +63,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 		usageReqMaskInternal = 1
 		usageReqMaskExternal = 8
 	}
-    
+
     MODULE
 	{
 		name = ModuleScienceContainer
@@ -77,12 +77,12 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 //------------------COMMUNITY TECHTREE-------------------------
 @PART[KKAOSS_LS_container_greenhouse]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = shortTermHabitation
+    @TechRequired = hydroponics
 }
 //------------------TAC LIFE SUPPORT CONFIG--------------------
 @PART[KKAOSS_LS_container_greenhouse]:FOR[PlanetarySurfaceStructures]:NEEDS[TacLifeSupport]
 {
-    
+
     @description = A small greenhouse that can grow food from waste and fertilizer.
 
     MODULE
@@ -91,9 +91,9 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 		converterName = Greenhouse
 		StartActionName = Start Farming
 		StopActionName = Stop Farming
-		tag = Life Support		
+		tag = Life Support
 		GeneratesHeat = false
-		
+
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
@@ -125,17 +125,17 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 			ResourceName = Oxygen
 			Ratio = 0.0002855896
 			DumpExcess = true
-		}	
+		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Food
 			Ratio = 0.0000169271
 			DumpExcess = false
-		}	
+		}
 
 		UseSpecialistBonus = false
 	}
-    
+
     RESOURCE
 	{
 		name = Fertilizer
@@ -153,12 +153,12 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 @PART[KKAOSS_LS_container_greenhouse]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
 {
     @description = A small greenhouse the grow more NOMS. This small container version is fully automated but has a lower efficiency than its big brother.
-    @TechRequired = automation
-    
+    @TechRequired = survivability
+
     MODULE
 	{
 		name = ModuleKPBSConverter
-		ConverterName = Greenhouse 
+		ConverterName = Greenhouse
 		tag = Greenhouse
 		StartActionName = Start Greenhouse
 		StopActionName = Stop Greenhouse
@@ -166,26 +166,26 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 		INPUT_RESOURCE
 		{
 			ResourceName = Mulch
-			Ratio =  0.001125
+			Ratio =  0.00045
 		}
         INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00015
+			Ratio =  0.000045
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 5
+			Ratio = 0.99
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Supplies
-			Ratio = 0.001275
+			Ratio = 0.000495
 			DumpExcess = False
 		}
 	}
-    
+
     RESOURCE
 	{
 		name = Mulch
@@ -210,11 +210,11 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
 {
     @TechRequired = scienceTech
     @cost = 2500
-    
+
     MODULE
 	{
 		name = ModuleKPBSConverter
-		ConverterName = Greenhouse 
+		ConverterName = Greenhouse
 		tag = Greenhouse
 		StartActionName = Start Greenhouse
 		StopActionName = Stop Greenhouse
@@ -246,7 +246,7 @@ PART:NEEDS[TacLifeSupport|USILifeSupport|IFILifeSupport|Snacks|Kerbalism]
     MODULE
 	{
 		name = ModuleKPBSConverter
-		ConverterName = Greenhouse 
+		ConverterName = Greenhouse
 		tag = Greenhouse
 		StartActionName = Start Greenhouse
 		StopActionName = Stop Greenhouse

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_USILS_AirScrubber.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_USILS_AirScrubber.cfg
@@ -1,0 +1,70 @@
+PART:NEEDS[USILifeSupport]
+{
+    MODEL
+    {
+        model = PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_CarbonExtractor
+    }
+
+    // --- general parameters ---
+    name = KKAOSS_LS_container_air_scrubber
+    module = Part
+    author = Nils277
+
+    // --- asset parameters ---
+    scale = 1
+    rescaleFactor = 1
+    CoMOffset = -0.45, 0, 0
+
+    // --- node definitions ---
+    node_stack_top = 0, 0, 0, 1, 0, 0, 1
+
+    // --- editor parameters ---
+    TechRequired = survivability
+    entryCost = 12000
+    cost = 2500
+    category = none
+    subcategory = 0
+    title = K&K Air Scrubber
+    manufacturer = K&K Advanced Orbit and Surface Structures
+	description = This life support container recycles air, reducing the need to rely on supplies. Though not very efficient, it does process a lot of air. Wernher von Kerman insists that it is not just a bunch of car air fresheners in a can.
+
+    // --- attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision ---
+    attachRules = 1,0,1,0,0
+    tags = life support converter recycl cck-lifesupport air
+
+    // --- standard part parameters ---
+    mass = 0.5
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 15
+    maxTemp = 2000 // = 3000
+}
+//------------------COMMUNITY TECHTREE-------------------------
+@PART[KKAOSS_LS_container_air_scrubber]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = basicScience
+}
+
+
+//------------------USI LIFE SUPPORT CONFIG--------------------
+@PART[KKAOSS_LS_container_air_scrubber]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = ModuleLifeSupportRecycler
+		CrewCapacity = 4
+		RecyclePercent = 0.4
+		ConverterName = Life Support
+		tag = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.8
+		}
+	}
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_USILS_Recycler.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_USILS_Recycler.cfg
@@ -22,7 +22,7 @@ PART:NEEDS[USILifeSupport]
     node_stack_top = 0, 0, 0, 1, 0, 0, 1
 
     // --- editor parameters ---
-    TechRequired = survivability
+    TechRequired = basicScience
     entryCost = 8000
     cost = 500
     category = none
@@ -45,12 +45,12 @@ PART:NEEDS[USILifeSupport]
     crashTolerance = 15
     maxTemp = 2000 // = 3000
     tags = life support recycler suplies mulch container cck-lifesupport
-    
+
     MODULE
 	{
 		name = ModuleLifeSupportRecycler
 		CrewCapacity = 2
-		RecyclePercent = .6
+		RecyclePercent = 0.6
 		ConverterName = Life Support
 		tag = Life Support
 		StartActionName = Start Life Support
@@ -61,12 +61,12 @@ PART:NEEDS[USILifeSupport]
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
-	}	
-    
+	}
+
 }
 
 //------------------COMMUNITY TECHTREE-------------------------
-@PART[KKAOSS_LS_container_airfilter]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
+@PART[KKAOSS_LS_container_USILS_recycler]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
 {
     @TechRequired = recycling
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_WaterPurifier.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_WaterPurifier.cfg
@@ -1,4 +1,4 @@
-PART:NEEDS[TacLifeSupport]
+PART:NEEDS[TacLifeSupport|USILifeSupport]
 {
     // Kerbal Space Program - Part Config
     // A container that can be used as an air filter for the LS mods
@@ -45,18 +45,22 @@ PART:NEEDS[TacLifeSupport]
     crashTolerance = 15
     maxTemp = 2000 // = 3000
     tags = Water Purifier life support container TAC cck-lifesupport
-    
+}
+
+//------------------TAC LS CONFIG-------------------------
+@PART[KKAOSS_LS_container_waterpurifier]:NEEDS[TacLifeSupport]
+{
 	MODULE
 	{
 		name = ModuleKPBSConverter
 		converterName = Water Purifier
 		StartActionName = Start WaterPurifier
 		StopActionName = Stop WaterPurifier
-		tag = Life Support		
+		tag = Life Support
 		GeneratesHeat = false
 		FillAmount = 1.0
         UseSpecialistBonus = false
-        
+
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
@@ -66,19 +70,19 @@ PART:NEEDS[TacLifeSupport]
 		{
 			ResourceName = WasteWater
 			Ratio = 0.00008548612
-		}		
+		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Water
 			Ratio = 0.00007693751
 			DumpExcess = false
-		}	
+		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Waste
 			Ratio = 0.0000119681
 			DumpExcess = true
-		}	
+		}
 
 
 	}
@@ -88,11 +92,41 @@ PART:NEEDS[TacLifeSupport]
 		name = WasteWater
 		amount = 0
 		maxAmount = 5
-	} 
+	}
 }
 
 //------------------COMMUNITY TECHTREE-------------------------
-@PART[KKAOSS_LS_container_waterpurifier]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
+@PART[KKAOSS_LS_container_waterpurifier]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree&TacLifeSupport]
 {
     @TechRequired = recycling
+}
+@PART[KKAOSS_LS_container_waterpurifier]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree&USILifeSupport]
+{
+	@TechRequired = shortTermHabitation
+}
+//------------------USI LS CONFIG--------------------
+@PART[KKAOSS_LS_container_waterpurifier]:FOR[PlanetarySurfaceStructures]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = ModuleLifeSupportRecycler
+		CrewCapacity = 1
+		RecyclePercent = 0.82
+		ConverterName = Purifier
+		StartActionName = Start Purifier
+		StopActionName = Stop Purifier
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.0
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.0064
+
+		}
+	}
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/USI-Recycler.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/USI-Recycler.cfg
@@ -25,14 +25,14 @@ PART:NEEDS[USILifeSupport]
 
 
 /   / --- editor parameters ---
-    TechRequired = survivability
+    TechRequired = basicScience
     entryCost = 16000
     cost = 5000
     category = none
     subcategory = 0
     title = K&K Recycler
     manufacturer = K&K Advanced Orbit and Surface Structures
-    description = A recycler that can be used to reduce all your life support needs. 
+    description = A recycler that can be used to reduce all your life support needs.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,1,1
@@ -49,8 +49,8 @@ PART:NEEDS[USILifeSupport]
     maxTemp = 2200
     fuelCrossFeed = True
     bulkheadProfiles = PlanetaryBase
-    tags = life support usi mulch supplies cck-lifesupport planetary base
-    
+    tags = life support usi mulch supplies cck-lifesupport planetary base recycler
+
     MODULE
 	{
 		name = ModuleLifeSupportRecycler
@@ -64,7 +64,23 @@ PART:NEEDS[USILifeSupport]
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 6
+			Ratio = 10.5
 		}
-	}	
+	}
+}
+//------------------COMMUNITY TECHTREE-------------------------
+@PART[KKAOSS_USI_Recicler_g]:FOR[PlanetarySurfaceStructures]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = recycling
+}
+
+//------------------CONNECTED LIVING SPACE---------------------
+@PART[KKAOSS_USI_Recicler_g]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+{
+    MODULE
+    {
+        name = ModuleConnectedLivingSpace
+        passable = true
+        impassablenodes = front, back
+    }
 }


### PR DESCRIPTION
# Large MM Patch
- Greenhouse slightly less powerful in production, better in hab.  (And uses a lot less EC.)
-  Central Hub is no longer a base on it’s own.
    - Base hab replaced with Hab Multiplier
    - Recycler removed.
    - Purifier adjusted to be more powerful, with less capacity.
    - Resource storage removed.
-  Habitats given a small multiplier, at the cost of Base Hab
- Coupola tweaked.
- Science lab loses recycler, gains small hab multiplier.

# Algae Container
Complete relook at the Algae container - now has several modes, including the original, which has been tweaked.

Modes are:
- ‘Dry’: Mulch+Ore -> Fertilizer
- ‘Wet’: Water+Ore - > Mulch+Fertilizer
- Soylent Green
- Soylent Red

# Other
Rebalanced the Greenhouse Container, Recycler, and USI Recycler - and moved tech tree nodes around a bit to balance against others.
Added the Air Scrubber and a USI-LS config to the Water Purifier Container - the first is an early-tech low-quality recycler, the second is a small purifier.  Both use already existing (and unused under USI-LS) models and textures.