### PR TITLE
small typo fix in part descriptions

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ContainerSystem/Storage_Size2_s.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ContainerSystem/Storage_Size2_s.cfg
@@ -35,7 +35,7 @@ PART
     subcategory = 0
     title = K&K Modular Inline 4X Storage 
     manufacturer = K&K Advanced Orbit and Surface Structures
-    description = The perfect solution for all those who don't now whether they have too many or too few resources. This modular storage provides space for up to four containers.
+    description = The perfect solution for all those who don't know whether they have too many or too few resources. This modular storage provides space for up to four containers.
 
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ContainerSystem/Storage_mid_g.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ContainerSystem/Storage_mid_g.cfg
@@ -37,7 +37,7 @@ PART
     subcategory = 0
     title = K&K Modular 4X Storage 
     manufacturer = K&K Advanced Orbit and Surface Structures
-    description = The perfect solution for all those who don't now whether they have too many or too few resources. This modular storage provides space for up to four containers.
+    description = The perfect solution for all those who don't know whether they have too many or too few resources. This modular storage provides space for up to four containers.
 
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision


### PR DESCRIPTION
In description for "K&K Modular Inline 4X Storage" and "K&K Modular 4X Storage"
("don't now" -> "don't know")