### PR TITLE
SEP Wedge name issue

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/SurfaceExperimentPackage/Container_SEP.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/SurfaceExperimentPackage/Container_SEP.cfg
@@ -32,7 +32,7 @@ PART:NEEDS[SEPScience]
 	cost = 1080
 	category = Science
 	subcategory = 0
-	title = #LOC_KPBS.sepstation.name
+	title = #LOC_KPBS.sepstation.title
 	manufacturer = #LOC_KPBS.agency
 	description = #LOC_KPBS.sepstation.description
 	


### PR DESCRIPTION
.cfg for the part was asking for 
title = #LOC_KPBS.sepstation.name

but wanted to use

title = #LOC_KPBS.sepstation.title

Should fix the name showing up in game as just the text string.