### PR TITLE
Fix nodes using both For and After specifiers

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/KPBS_MM_Kerbalism_Habitation.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/KPBS_MM_Kerbalism_Habitation.cfg
@@ -1,5 +1,5 @@
 //-------------The Habitat MK2-----------------
-@PART[KKAOSS_Habitat_MK2_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Habitat_MK2_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -12,7 +12,7 @@
 }
 
 //-------------The Laboratory-----------------
-@PART[KKAOSS_Science_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Science_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -25,7 +25,7 @@
 }
 
 //-------------The Greenhouse-----------------
-@PART[KKAOSS_Greenhouse_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Greenhouse_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -38,7 +38,7 @@
 }
 
 //-------------The Control Room-----------------
-@PART[KKAOSS_Control_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Control_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -48,7 +48,7 @@
 }
 
 //-------------The Cupola-----------------
-@PART[KKAOSS_Cupola_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Cupola_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -58,7 +58,7 @@
 }
 
 //-------------The Freezer-----------------
-@PART[CRY-5000Freezer]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[CRY-5000Freezer]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -68,7 +68,7 @@
 }
 
 //-------------The Habitat MK1-----------------
-@PART[KKAOSS_Habitat_MK1_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Habitat_MK1_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -78,7 +78,7 @@
 }
 
 //-------------The Central Hub-----------------
-@PART[KKAOSS_Central_Hub]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Central_Hub]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -88,7 +88,7 @@
 }
 
 //-------------The Airlock-----------------
-@PART[KKAOSS_airlock_mid_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_airlock_mid_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -98,7 +98,7 @@
 }
 
 //-------------The Airlock End-----------------
-@PART[KKAOSS_airlock_end_g]:FOR[PlanetarySurfaceStructures]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_airlock_end_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_IFI_LIFE_SUPPORT.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_IFI_LIFE_SUPPORT.cfg
@@ -32,7 +32,7 @@
     }
 }
 
-@PART[KKAOSS_Central_Hub]:FOR[PlanetarySurfaceStructures]:NEEDS[IFILifeSupport]:AFTER[IFILifeSupport]
+@PART[KKAOSS_Central_Hub]:NEEDS[IFILifeSupport]:AFTER[IFILifeSupport]
 {
     !RESOURCE[LifeSupport]{}
     RESOURCE
@@ -43,7 +43,7 @@
     }
 }
 
-@PART[KKAOSS_Habitat_MK2_g]:FOR[PlanetarySurfaceStructures]:NEEDS[IFILifeSupport]:AFTER[IFILifeSupport]
+@PART[KKAOSS_Habitat_MK2_g]:NEEDS[IFILifeSupport]:AFTER[IFILifeSupport]
 {
     !RESOURCE[LifeSupport]{}
     RESOURCE
@@ -54,7 +54,7 @@
     }
 }
 
-@PART[KKAOSS_Habitat_MK1_g]:FOR[PlanetarySurfaceStructures]:NEEDS[IFILifeSupport]:AFTER[IFILifeSupport]
+@PART[KKAOSS_Habitat_MK1_g]:NEEDS[IFILifeSupport]:AFTER[IFILifeSupport]
 {   
     !RESOURCE[LifeSupport]{}
     RESOURCE

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_TAC_LS.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_TAC_LS.cfg
@@ -65,7 +65,7 @@
 	}
 }
 
-@PART[KKAOSS_Habitat_MK2_g]:FOR[PlanetarySurfaceStructures]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
+@PART[KKAOSS_Habitat_MK2_g]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
 {
     !RESOURCE[Food]{}
     !RESOURCE[Water]{}
@@ -110,7 +110,7 @@
         maxAmount = 5.544
     }
 }
-@PART[KKAOSS_Habitat_MK1_g]:FOR[PlanetarySurfaceStructures]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
+@PART[KKAOSS_Habitat_MK1_g]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
 {
     !RESOURCE[Food]{}
     !RESOURCE[Water]{}
@@ -155,7 +155,7 @@
         maxAmount = 3.696
     }
 }
-@PART[KKAOSS_Central_Hub]:FOR[PlanetarySurfaceStructures]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
+@PART[KKAOSS_Central_Hub]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
 {
     !RESOURCE[Food]{}
     !RESOURCE[Water]{}


### PR DESCRIPTION
As of at least Mod Manager 3.0.1, an entry cannot have both a For
and After specifier.

This PR has been tested with TAC.