### PR TITLE
Fix for localization

### DIFF
--- a/Sources/PlanetarySurfaceStructures/PlanetaryModule.cs
+++ b/Sources/PlanetarySurfaceStructures/PlanetaryModule.cs
@@ -112,7 +112,7 @@ namespace PlanetarySurfaceStructures
         /**
 		 * The action that can be used for makros to toggle the state of the module
 		 */
-        [KSPAction("#LOC_KPBS.planetarymodule.event.toggle")]
+        [KSPAction("#LOC_KPBS.planetarymodule.action.toggle")]
         public void toggleAction(KSPActionParam param) 
 		{
             if ((availableInVessel) && (!(moduleStatus == ModuleState.Deployed) || (this.part.protoModuleCrew.Count <= crewCapcityRetracted))) {


### PR DESCRIPTION
A small fix for a minor localization issue. Action groups for "Toggle deployment" on planetary modules were shown as "#LOC_KPBS.planetarymodule.action.toggle" instead of the respective translation.