### PR TITLE
Config updates for USITools changes

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_USI_LS.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/LifeSupport/KPBS_MM_USI_LS.cfg
@@ -41,10 +41,26 @@
 	}
 
 
-
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter
+		moduleIndex = 0
+		currentLoadout = 0
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
     MODULE
 	{
-    	name = ModuleHabitation
+    	name = USILS_HabitationSwapOption
 		BaseKerbalMonths = 0
 		CrewCapacity = 4
 		BaseHabMultiplier = 1
@@ -88,9 +104,39 @@
 	
     !MODULE[ModuleScienceConverter]{}
 	
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter 1
+		moduleIndex = 0
+		currentLoadout = 0
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter 2
+		moduleIndex = 1
+		currentLoadout = 1
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
     MODULE
 	{
-        name = ModuleHabitation
+    	name = USILS_HabitationSwapOption
 		BaseKerbalMonths = 0
 		CrewCapacity = 6
 		BaseHabMultiplier = 1.1
@@ -106,7 +152,7 @@
 
     MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 1
 		RecyclePercent = 0.85
 		ConverterName = #LOC_KPBS.waterfilter.name
@@ -144,9 +190,26 @@
 		amount = 50
 		maxAmount = 50
 	}
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter
+		moduleIndex = 0
+		currentLoadout = 0
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
     MODULE
 	{
-        name = ModuleHabitation
+    	name = USILS_HabitationSwapOption
 		ConverterName = #LOC_KPBS.habitat.name
 		StartActionName = #LOC_KPBS.habitat.start
 		StopActionName = #LOC_KPBS.habitat.stop
@@ -178,9 +241,26 @@
 		amount = 25
 		maxAmount = 25
 	}
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter
+		moduleIndex = 0
+		currentLoadout = 0
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
     MODULE
 	{
-    	name = ModuleHabitation
+    	name = USILS_HabitationSwapOption
 		ConverterName = #LOC_KPBS.habitat.name
 		StartActionName = #LOC_KPBS.habitat.start
 		StopActionName = #LOC_KPBS.habitat.stop
@@ -202,12 +282,24 @@
 
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
-
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter
+		moduleIndex = 0
+		currentLoadout = 0
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
     MODULE
 	{
-		name = ModuleHabitation
+    	name = USILS_HabitationSwapOption
 		BaseKerbalMonths = 0
 		CrewCapacity = 2
 		BaseHabMultiplier = .55
@@ -228,12 +320,24 @@
 
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
-
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Converter
+		moduleIndex = 0
+		currentLoadout = 0
+		hasPermanentLoadout = true
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
     MODULE
 	{
-		name = ModuleHabitation
+    	name = USILS_HabitationSwapOption
 		KerbalMonths = 0
 		CrewCapacity = 4
 		HabMultiplier = 0.2
@@ -248,7 +352,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleResourceConverter_USI]:HAS[#ConverterName[Agroponics]]]:NEEDS[USILifeSupport,PlanetaryBaseInc]
+@PART[*]:HAS[@MODULE[USI_ConverterSwapOption]:HAS[#ConverterName[Agroponics]]]:NEEDS[USILifeSupport,PlanetaryBaseInc]
 {
     &MODULE[ModuleScienceExperiment]
 	{


### PR DESCRIPTION
This is an example of the new way that USI converters are setup. I have tested the config for the central hub (since I use it frequently in my own saves) but not the others. All of the container parts will require updates as well. Note the removal of ModuleLifeSupport. It has been deprecated and replaced by a VesselModule, so it is no longer required as a module on each part. Feel free to ping me on the KSP forums (@DoktorKrogg) with any questions.