### PR TITLE
Snack Switcher for Large Snacks Container

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Snacks_big.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Snacks_big.cfg
@@ -46,11 +46,46 @@ PART:NEEDS[Snacks]
     maxTemp = 2000 // = 3000
     bulkheadProfiles = Container
     
-	RESOURCE
+    	MODULE
 	{
-		name= Snacks
-		amount = 1000
-		maxAmount = 1000
+		name = SnacksResourceSwitcher
+		defaultOption = Snacks
+		OPTION
+		{
+			name = Snacks
+			RESOURCE
+			{
+				name = Snacks
+				amount = 1000
+				maxAmount = 1000
+			}
+		}
+		OPTION
+		{
+			name = Soil
+			RESOURCE
+			{
+				name = Soil
+				amount = 0
+				maxAmount = 1000
+			}
+		}
+		OPTION
+		{
+			name = Snacks and Soil
+			RESOURCE
+			{
+				name = Snacks
+				amount = 500
+				maxAmount = 500
+			}
+			RESOURCE
+			{
+				name = Soil
+				amount = 0
+				maxAmount = 500
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- updated so that it uses the Snack Switcher module used by the default Snack Tins