### PR TITLE
Snack Switcher for Small Snacks Container

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Snacks_small.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/LifeSupport/Container_Snacks_small.cfg
@@ -46,11 +46,46 @@ PART:NEEDS[Snacks]
     maxTemp = 2000 // = 3000
     bulkheadProfiles = Container
     
-	RESOURCE
+    	MODULE
 	{
-		name= Snacks
-		amount = 500
-		maxAmount = 500
+		name = SnacksResourceSwitcher
+		defaultOption = Snacks
+		OPTION
+		{
+			name = Snacks
+			RESOURCE
+			{
+				name = Snacks
+				amount = 500
+				maxAmount = 500
+			}
+		}
+		OPTION
+		{
+			name = Soil
+			RESOURCE
+			{
+				name = Soil
+				amount = 0
+				maxAmount = 500
+			}
+		}
+		OPTION
+		{
+			name = Snacks and Soil
+			RESOURCE
+			{
+				name = Snacks
+				amount = 250
+				maxAmount = 250
+			}
+			RESOURCE
+			{
+				name = Soil
+				amount = 0
+				maxAmount = 250
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- updated so that it uses the Snack Switcher module used by the default Snack Tins