### PR TITLE
Update gangway_flexible.cfg for CLS compatibility

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/KAS/gangway_flexible.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/KAS/gangway_flexible.cfg
@@ -67,7 +67,7 @@ PART:NEEDS[KAS]
 		allowCoupling = true
 
 		// KASLinkSourceBase
-		coupleMode = SetViaGUI // AlwaysCoupled - Allow switching to Docked mode
+		coupleMode = AlwaysCoupled
 		jointName = corridorJoint
 		linkRendererName = corridorRenderer
 		sndPathDock = KAS/Sounds/plugdocked

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/KAS/gangway_flexible.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/KAS/gangway_flexible.cfg
@@ -67,7 +67,7 @@ PART:NEEDS[KAS]
 		allowCoupling = true
 
 		// KASLinkSourceBase
-		coupleMode = AlwaysCoupled
+		coupleMode = SetViaGUI // AlwaysCoupled - Allow switching to Docked mode
 		jointName = corridorJoint
 		linkRendererName = corridorRenderer
 		sndPathDock = KAS/Sounds/plugdocked
@@ -124,6 +124,15 @@ PART:NEEDS[KAS]
 		anchorAtSource = 0, 0, 0
 		anchorAtTarget = 0, 0, 0
 	}
+	MODULE // Allow this part to also act as a target for connections.
+	{
+		name = KASLinkTargetBase
+		linkType = KPBSCorridor
+		linkTypeDisplayName = #LOC_KPBS.flexiblecorridor.connector
+		attachNodeName = top
+		allowCoupling = true
+	}
+
 }
 
 @PART[KKAOSS_KAS_Flexible_Corridor]:FOR[PlanetarySurfaceStructures]:NEEDS[ConnectedLivingSpace]:HAS[!MODULE[ModuleConnectedLivingSpace]]


### PR DESCRIPTION
Nils, 
I couldn't get the PR IgorZ submitted working without changes. I couldn't figure out how to connect his gangway to anything.  I'm not 100% satisfied with this, but it works. This change allows the flexible gangway to operate as both a target and source for corridor links like the legacy corridors. There is another change that I don't like that is required for CLS or even stock transfers to function. The coupleMode needs to be docked for the connect components to be seen as one vessel. AlwaysCoupled doesn't do that, but it can be set with the SetViaGUI option. I think it should be transparent. I've messaged IgorZ about this, but he's on a trip for the next two weeks. Another option you should take a look at before shipping it, is the pipeBendResistance. I didn't change it from Igor's value, but I think it's a bit too high and is forcing some extra curvature into the connection.