### PR TITLE
Feature mksparts

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/de-de.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/de-de.cfg
@@ -1081,5 +1081,10 @@ Localization
         #LOC_KPBS.usirecycler.title = K&K Recycler
         #LOC_KPBS.usirecycler.description = Ein Recycler, der die benötigten Ressourcen für die Lebenserhaltung reduziert.
         #LOC_KPBS.usirecycler.tags = leben erhaltung mulch essen nahrung trinken wasser cck-lifesupport planetae basis recycler
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = Kerbals kommen her um vom WOLF transportiert zu werden.
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/de-de.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/de-de.cfg
@@ -1083,8 +1083,22 @@ Localization
         #LOC_KPBS.usirecycler.tags = leben erhaltung mulch essen nahrung trinken wasser cck-lifesupport planetae basis recycler
 		
 		//--- USI MKS WOLF Terminal ---
-		#LOC_KPBS.MKS.wolfterminal.title = WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = Kerbals kommen her um vom WOLF transportiert zu werden.
 		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Werkstatt
+		#LOC_KPBS.MKS.workshop.description = Endlich mal ein Platz wo man Bill verstecken kann. Hält die Maschinen der Siedlung auf dem Laufenden (wie von Bill selbst bestätigt). Kann auch kleine Werkzeuge fertigen.
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	usi mks werkstatt reparatur
+		#LOC_KPBS.MKS.workshop.mkit.name = Material-Bausätze
+		#LOC_KPBS.MKS.workshop.mkit.start = Starte Material-Bausätze
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stoppe Material-Bausätze
+		#LOC_KPBS.MKS.workshop.machinery.name = Maschienen
+		#LOC_KPBS.MKS.workshop.machinery.start = Starte Maschienen
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stoppe Maschienen
+		#LOC_KPBS.MKS.workshop.shop.name = Maschinenwerkstatt
+		#LOC_KPBS.MKS.workshop.shop.start = Starte Maschinenwerkstatt
+		#LOC_KPBS.MKS.workshop.shop.stop = Stoppe Maschinenwerkstatt
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/en-us.cfg
@@ -1082,5 +1082,10 @@ Localization
         #LOC_KPBS.usirecycler.title = K&K Recycler
         #LOC_KPBS.usirecycler.description = A recycler that can be used to reduce all your life support needs.
         #LOC_KPBS.usirecycler.tags = life support usi mulch supplies cck-lifesupport planetary base recycler
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = Where Kerbals go when they want to hitch a ride on a WOLF transport route.
+		#LOC_KPBS.MKS.wolfterminal.tags = usi planetary base terminal wolf cck-usi-wolf
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/en-us.cfg
@@ -1087,5 +1087,19 @@ Localization
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = Where Kerbals go when they want to hitch a ride on a WOLF transport route.
 		#LOC_KPBS.MKS.wolfterminal.tags = usi planetary base terminal wolf cck-usi-wolf
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = Finally a place for hiding Bill. Keeps the colony machinery running at peak performance (as certified by Bill). Also includes a miniature machine shop.
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	usi mks workshop repair
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/es-es.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/es-es.cfg
@@ -1086,5 +1086,20 @@ Localization
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = TBD
 		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = TBD
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop		
+		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/es-es.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/es-es.cfg
@@ -1081,5 +1081,10 @@ Localization
         #LOC_KPBS.usirecycler.title = K&K Reciclador
         #LOC_KPBS.usirecycler.description = Un reciclador que se puede utilizar para reducir todas sus necesidades de soporte de vida.
         #LOC_KPBS.usirecycler.tags = soporte vital usi mantillo suministros cck-lifesupport base planetaria reciclador
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = TBD
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/fr-fr.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/fr-fr.cfg
@@ -1081,5 +1081,19 @@ Localization
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = TBD
 		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = TBD
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/fr-fr.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/fr-fr.cfg
@@ -1076,5 +1076,10 @@ Localization
         #LOC_KPBS.usirecycler.title = Recycleur K&K
         #LOC_KPBS.usirecycler.description = Un recycleur qui peut être utilisé pour réduire tous vos besoins en survie.
         #LOC_KPBS.usirecycler.tags = life support usi mulch supplies cck-lifesupport planetary base recycler
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = TBD
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/it-it.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/it-it.cfg
@@ -1081,5 +1081,10 @@ Localization
         #LOC_KPBS.usirecycler.title = K&K Riciclatore
         #LOC_KPBS.usirecycler.description = Un riciclatore che può essere utilizzato per ridurre tutte le esigenze di supporto vitale.
         #LOC_KPBS.usirecycler.tags = life support usi mulch supplies cck-lifesupport planetary base recycler riciclatore
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = TBD
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/it-it.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/it-it.cfg
@@ -1086,5 +1086,19 @@ Localization
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = TBD
 		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = TBD
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/pt-br.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/pt-br.cfg
@@ -1076,5 +1076,10 @@ Localization
         #LOC_KPBS.usirecycler.title = K&K Recycler
         #LOC_KPBS.usirecycler.description = A recycler that can be used to reduce all your life support needs.
         #LOC_KPBS.usirecycler.tags = life support usi mulch supplies cck-lifesupport planetary base recycler
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = TBD
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/pt-br.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/pt-br.cfg
@@ -1080,6 +1080,20 @@ Localization
 		//--- USI MKS WOLF Terminal ---
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = TBD
-		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf		
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf	
+
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = TBD
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/ru.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/ru.cfg
@@ -1087,5 +1087,10 @@ Localization
         #LOC_KPBS.usirecycler.title = K&K Модуль Переработки
         #LOC_KPBS.usirecycler.description = Модуль переработки может использоваться для снижения потребления припасов жизнеобеспечения.
         #LOC_KPBS.usirecycler.tags = life support usi mulch supplies cck-lifesupport planetary base recycler планетарный база жизненная поддержка контейнер
+		
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = TBD
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/ru.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/ru.cfg
@@ -1092,5 +1092,19 @@ Localization
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = TBD
 		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = TBD
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/zh-cn.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/zh-cn.cfg
@@ -1080,5 +1080,19 @@
 		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
 		#LOC_KPBS.MKS.wolfterminal.description = TBD
 		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf	
+		
+		//--- USI MKS Workshop ---
+		#LOC_KPBS.MKS.workshop.title = K&K Workshop
+		#LOC_KPBS.MKS.workshop.description = TBD
+		#LOC_KPBS.MKS.workshop.tags = cck-usi-manufacturing	
+		#LOC_KPBS.MKS.workshop.mkit.name = MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.start = Start MaterialKits
+		#LOC_KPBS.MKS.workshop.mkit.stop = Stop MaterialKits
+		#LOC_KPBS.MKS.workshop.machinery.name = Machinery
+		#LOC_KPBS.MKS.workshop.machinery.start = Start Machinery
+		#LOC_KPBS.MKS.workshop.machinery.stop = Stop Machinery
+		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
+		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop		
 	}
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/zh-cn.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/zh-cn.cfg
@@ -1075,5 +1075,10 @@
         #LOC_KPBS.usirecycler.title = K&K循环设备
         #LOC_KPBS.usirecycler.description = 一个循环设备用来减少生命维持所需的补给。
         #LOC_KPBS.usirecycler.tags = 生命维持 USI 有机质 补给 cck-lifesupport 行星 基地 循环
-    }
+    
+		//--- USI MKS WOLF Terminal ---
+		#LOC_KPBS.MKS.wolfterminal.title = K&K WOLF Terminal
+		#LOC_KPBS.MKS.wolfterminal.description = TBD
+		#LOC_KPBS.MKS.wolfterminal.tags = cck-usi-wolf	
+	}
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/MKS/KPBS_MM_MKS_Containers.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/MKS/KPBS_MM_MKS_Containers.cfg
@@ -2,7 +2,7 @@
 // adds USI warehouse to common containers/tanks, so that they can participate
 // in MKS local logistics
 //
-@PART[KKAOSS_Fuel_Tank,KKAOSS_Fuel_Tank_small,KKAOSS_Liquid_Fuel_Tank,KKAOSS_Ore_Tank,KKAOSS_Small_Ore_Tank,KKAOSS_RCS_Tank,KKAOSS_Rocket_Fuel_Tank,KKAOSS_small_Rocket_Fuel_Tank,KKAOSS_Xenon_Tank,KKAOSS_Nuclear_Fuel]:FOR[PlanetarySurfaceStructures]:NEEDS[MKS&!KPBStoMKS]
+@PART[KKAOSS_Fuel_Tank,KKAOSS_Fuel_Tank_small,KKAOSS_Liquid_Fuel_Tank,KKAOSS_Ore_Tank,KKAOSS_Small_Ore_Tank,KKAOSS_RCS_Tank,KKAOSS_Rocket_Fuel_Tank,KKAOSS_small_Rocket_Fuel_Tank,KKAOSS_Xenon_Tank,KKAOSS_Nuclear_Fuel,DF_Glykerol_Tank]:FOR[PlanetarySurfaceStructures]:NEEDS[MKS&!KPBStoMKS]
 {
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/MKSWorkshop.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/MKSWorkshop.cfg
@@ -1,0 +1,359 @@
+PART:NEEDS[MKS]
+{
+    // Kerbal Space Program - Part Config
+    // MKS Workshop
+
+    MODEL
+    {
+        model = PlanetaryBaseInc/ModSupport/Parts/OSE Workshop/OSE_workshop
+    }
+
+    // --- general parameters ---
+    name = KKAOSS_MKS_Workshop
+    module = Part
+    author = Nils277/Grimmas 
+
+    // --- asset parameters ---
+    rescaleFactor = 1.0
+
+
+    // --- node definitions ---
+    node_stack_top = 0, 1.5580, 0, 0, 1, 0, 1
+    node_stack_bottom = 0, -1.5580, 0, 0, -1, 0, 1
+    node_stack_front = 0, 0, -0.73494, 0, 0, -1, 0
+    node_stack_back = 0, 0, 0.6266, 0, 0, 1, 0
+
+
+
+    // --- editor parameters ---
+    TechRequired = advExploration
+    entryCost = 12500
+    cost = 75000
+    category = Utility
+    subcategory = 0
+    title = #LOC_KPBS.MKS.workshop.title
+    manufacturer = #LOC_KPBS.agency
+    description = #LOC_KPBS.MKS.workshop.description
+
+
+    // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+    attachRules = 1,0,1,1,1
+
+
+    // --- standard part parameters ---
+    mass = 2.5
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 1
+    crashTolerance = 20
+    CrewCapacity = 2
+    maxTemp = 2100
+    fuelCrossFeed = True
+    bulkheadProfiles = PlanetaryBase
+    tags = #LOC_KPBS.MKS.workshop.tags
+    
+    INTERNAL
+    {
+	    name = KKAOSS_OSE_workshop_internal
+    }
+	
+	MODULE
+    {
+        name = ModuleColorChanger
+        shaderProperty = _EmissiveColor
+        animRate = 0.8
+        animState = false
+        useRate = true
+        toggleInEditor = true
+        toggleInFlight = true
+        unfocusedRange = 5
+        toggleName = #autoLOC_900823
+        eventOnName = #autoLOC_6001406
+        eventOffName = #autoLOC_6001407        
+        defaultActionGroup = None
+        toggleAction = True
+        redCurve
+        {
+            key = 0 0
+            key = 1 0.45
+        }
+        greenCurve
+        {
+            key = 0 0
+            key = 1 0.45
+        }
+        blueCurve
+        {
+            key = 0 0
+            key = 1 1.0
+        }
+        alphaCurve
+        {
+            key = 0 1
+        }
+    }
+	
+	
+	// can help with EVA construction
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionForeman
+	}
+	
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionHelper
+		KonstructionPoints = 8
+	}
+	
+	// receives remote power
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+	
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		ApplyBonuses = false
+	}
+	
+	// can participate in local logistics
+	MODULE
+	{
+		name = ModuleLogisticsConsumer
+	}
+	
+	// even up to 2km away
+	MODULE
+	{
+		name = ModuleResourceDistributor
+	}
+	
+	// automatically repairs machines in range
+	MODULE
+	{
+		name = ModuleAutoRepairer	
+	}
+	
+	// honestly not sure what this really does but sounds useful and is part of other MKS workshops
+	MODULE
+	{
+		name = ModuleWeightDistributableCargo
+	}
+	
+	// disassembled parts can drop their MK here
+	MODULE
+	{
+		name = USI_ModuleRecycleBin
+	}
+	
+	// modules adapted from Ranger_Workshop
+	
+	MODULE
+	{
+		name = USI_SwapController 
+		ResourceCosts = SpecializedParts,50,MaterialKits,300,ElectricCharge,600
+	}
+	MODULE
+	{
+		name = USI_SwappableBay 
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = #LOC_KPBS.MKS.workshop.mkit.name
+		StartActionName = #LOC_KPBS.MKS.workshop.mkit.start
+		StopActionName = #LOC_KPBS.MKS.workshop.mkit.stop
+
+		UseSpecialistBonus = true
+		ExperienceEffect = ConverterSkill
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = Metals
+			Ratio = 0.0112
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Chemicals
+			Ratio = 0.0056
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Polymers
+			Ratio = 0.0112
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 56
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00005
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00005
+			DumpExcess = true
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = MaterialKits
+			Ratio = 0.028
+			DumpExcess = False
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 2500
+		}
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = #LOC_KPBS.MKS.workshop.machinery.name 
+		StartActionName = #LOC_KPBS.MKS.workshop.machinery.start 
+		StopActionName = #LOC_KPBS.MKS.workshop.machinery.stop 
+
+		UseSpecialistBonus = true
+		ExperienceEffect = ConverterSkill
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = MaterialKits
+			Ratio = 0.0224
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = SpecializedParts
+			Ratio = 0.0056
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 56
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.028
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00005
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00005
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 2500
+		}
+	}
+	MODULE
+	{
+		name = USI_EfficiencyBoosterSwapOption
+		ConverterName = #LOC_KPBS.MKS.workshop.shop.name
+		StartActionName = #LOC_KPBS.MKS.workshop.shop.start
+		StopActionName = #LOC_KPBS.MKS.workshop.shop.stop
+
+		EfficiencyTag = Workshop
+		EfficiencyMultiplier = 20
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 75
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00005
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00005
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 2500
+		}
+	}	
+	
+    RESOURCE
+    {
+        name = ElectricCharge
+        amount = 1000
+        maxAmount = 1000
+    }
+	
+	RESOURCE
+	{
+		name = Machinery
+		amount = 0    
+		maxAmount = 2000
+		isTweakable = True
+	}
+	
+	RESOURCE
+	{
+		name = MaterialKits
+		amount = 0    
+		maxAmount = 1000
+		isTweakable = True
+	}
+
+	RESOURCE
+	{
+		name = SpecializedParts
+		amount = 0
+		maxAmount = 200
+		isTweakable = True
+	}
+	
+	RESOURCE
+	{
+		name = Recyclables
+		amount = 0
+		maxAmount = 2500
+		isTweakable = True
+	}
+	
+	// not sure about this one
+//	RESOURCE
+//	{
+//		name = Construction
+//		amount = 0
+//		maxAmount = 2000
+//	}	
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
@@ -49,7 +49,7 @@ PART:NEEDS[MKS&USI_WOLF]
     maxTemp = 10000
     bulkheadProfiles = PlanetaryBase
     tags = #LOC_KPBS.MKS.wolfterminal.tags
-	CrewCapacity = 8
+	CrewCapacity = 6
 	
 	
 	INTERNAL

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
@@ -11,7 +11,7 @@ PART:NEEDS[MKS&USI_WOLF]
     
     
     // --- general parameters ---
-    name = KKAOSS_WOLFTerminal
+    name = KKAOSS_MKS_WOLFTerminal
     module = Part
     author = Nils277/Grimmas 
 
@@ -49,6 +49,14 @@ PART:NEEDS[MKS&USI_WOLF]
     maxTemp = 10000
     bulkheadProfiles = PlanetaryBase
     tags = #LOC_KPBS.MKS.wolfterminal.tags
+	CrewCapacity = 8
+	
+	
+	INTERNAL
+	{
+		name = KKAOSS_Central_Hub_internal
+	}
+	
     
     MODULE
     {

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
@@ -1,0 +1,110 @@
+PART:NEEDS[MKS&USI_WOLF]
+{
+    // Kerbal Space Program - Part Config
+    // A WOLF crew/passenger terminal
+	
+	// intentionally reusing existing EL model here
+    MODEL
+    {
+        model = PlanetaryBaseInc/ModSupport/Parts/Extraplanetary Launchpads/Launchpad
+    }
+    
+    
+    // --- general parameters ---
+    name = KKAOSS_WOLFTerminal
+    module = Part
+    author = Nils277/Grimmas 
+
+    // --- asset parameters ---
+    scale = 1
+    rescaleFactor = 1
+
+    // --- node definitions ---
+    node_stack_top = 0, 2.1853, 0, 0, 1, 0, 1
+    node_stack_bottom = 0, -2.1853, 0, 0, -1, 0, 1
+    node_stack_back = 0, 0, 0.6266, 0, 0, 1, 0
+
+    // --- editor parameters ---
+    TechRequired = specializedConstruction
+    entryCost = 120000
+    cost = 60000
+    category = Structural
+    subcategory = 0
+    title = #LOC_KPBS.MKS.wolfterminal.title
+    manufacturer = #LOC_KPBS.agency
+    description = #LOC_KPBS.MKS.wolfterminal.description
+
+
+    // --- attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision ---
+    attachRules = 1,0,1,1,0
+
+
+    // --- standard part parameters ---
+    mass = 4
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 15
+    maxTemp = 10000
+    bulkheadProfiles = PlanetaryBase
+    tags = #LOC_KPBS.MKS.wolfterminal.tags
+    
+    MODULE
+    {
+       name = ModuleAnimateGeneric
+       animationName = LaunchpadOpen
+       startEventGUIName = #LOC_KPBS.launchpad.open
+       endEventGUIName = #LOC_KPBS.launchpad.close
+    }    
+    
+	
+	// based on WOLF_Terminal_375 by Roverdude/DoktorKrogg
+	
+	MODULE
+  	{
+  		name = ModuleCommand
+  		minimumCrew = 0
+  		RESOURCE
+  		{
+      		name=ElectricCharge
+      		rate = 0.02777778
+  		}
+  	}
+	
+	// can receive remote power
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+	
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost
+		EfficiencyMultiplier = 6
+	}
+	
+	// the actual WOLF terminal
+	MODULE
+	{
+		name = WOLF_TerminalModule
+		ModuleName = #LOC_USI_WOLF_TerminalModuleName
+		PartInfo = #LOC_USI_WOLF_TerminalModule_PartInfo
+	}
+
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 1000
+		maxAmount = 1000
+		isTweakable = true
+	}      
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/WOLFTerminal.cfg
@@ -28,7 +28,7 @@ PART:NEEDS[MKS&USI_WOLF]
     TechRequired = specializedConstruction
     entryCost = 120000
     cost = 60000
-    category = Structural
+    category = Payload
     subcategory = 0
     title = #LOC_KPBS.MKS.wolfterminal.title
     manufacturer = #LOC_KPBS.agency

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Spaces/Workshops/OSE_workshop_internal.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Spaces/Workshops/OSE_workshop_internal.cfg
@@ -1,4 +1,4 @@
-INTERNAL:NEEDS[Workshop]
+INTERNAL:NEEDS[Workshop|MKS]
 {
 	name = KKAOSS_OSE_workshop_internal
 	


### PR DESCRIPTION
Two "new" MKS-enabled parts for KPBS bases.

The Workshop reuses the OSE Workshop assets but with MKS modules like the auto-repair and efficiency boost and MKit/machinery fabrication.

The Terminal reuses the EL Launchpad assets but turns it into an endpoint for MKS WOLF crew transfers. Unfortunately, I ran into [an issue](https://github.com/UmbraSpaceIndustries/MKS/issues/1530) with the pre-release MKS code that prevents the crew transfer window from opening, but that's unrelated to the part itself.  

Since both parts reuse existing KPBS models and textures, this is easy on the system resources. 