### PR TITLE
switchable MKS containers

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/de-de.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/de-de.cfg
@@ -1122,5 +1122,25 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.name = Maschinenwerkstatt
 		#LOC_KPBS.MKS.workshop.shop.start = Starte Maschinenwerkstatt
 		#LOC_KPBS.MKS.workshop.shop.stop = Stoppe Maschinenwerkstatt
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/en-us.cfg
@@ -1124,5 +1124,28 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids.
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container 
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids.
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids.
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids.
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids
+		
+		
+		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/es-es.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/es-es.cfg
@@ -1123,5 +1123,25 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop //TODO
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop  //TODO
 		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
+		
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/fr-fr.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/fr-fr.cfg
@@ -1117,5 +1117,25 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop  //TODO
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop //TODO
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop  //TODO	
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/it-it.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/it-it.cfg
@@ -1122,5 +1122,25 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop  //TODO
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop //TODO
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop  //TODO
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/pt-br.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/pt-br.cfg
@@ -1117,5 +1117,25 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop  //TODO
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop //TODO
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop  //TODO	
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/ru.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/ru.cfg
@@ -1128,5 +1128,25 @@ Localization
 		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop  //TODO
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop //TODO
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop  //TODO		
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
     }
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/zh-cn.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/Localization/zh-cn.cfg
@@ -1116,5 +1116,25 @@
 		#LOC_KPBS.MKS.workshop.shop.name = Machine Shop  //TODO
 		#LOC_KPBS.MKS.workshop.shop.start = Start Machine Shop //TODO
 		#LOC_KPBS.MKS.workshop.shop.stop = Stop Machine Shop  //TODO	
+		
+		//--- USI MKS Small Solids Container ---
+		#LOC_KPBS.MKS.containersolidssmall.title = K&K Small Solids Container //TODO
+		#LOC_KPBS.MKS.containersolidssmall.description = A small modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolidssmall.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Large Solids Container ---
+		#LOC_KPBS.MKS.containersolids.title = K&K Solids Container //TODO
+		#LOC_KPBS.MKS.containersolids.description = A large modular tank that can be used for storing a wide variety of solids. //TODO
+		#LOC_KPBS.MKS.containersolids.tags = usi mks container solids //TODO
+		
+		//--- USI MKS Small Liquids Container ---
+		#LOC_KPBS.MKS.containerliquidssmall.title = K&K Small Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.description = A small modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquidssmall.tags = usi mks container liquids //TODO
+		
+		//--- USI MKS Large Liquids Container ---
+		#LOC_KPBS.MKS.containerliquids.title = K&K Liquids Container //TODO
+		#LOC_KPBS.MKS.containerliquids.description = A large modular tank that can be used for storing a wide variety of liquids. //TODO
+		#LOC_KPBS.MKS.containerliquids.tags = usi mks container liquids //TODO
 	}
 }

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTank.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTank.cfg
@@ -53,12 +53,6 @@ PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
 		name = USI_ModuleResourceWarehouse
 	}
 
-	// can be emptied in flight
-    //MODULE
-    //{
-    //    name = ModuleFuelJettison
-    //}
-	
 	// configurable storage
 	
 	MODULE

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTank.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTank.cfg
@@ -1,0 +1,88 @@
+PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
+{
+    // Kerbal Space Program - Part Config
+    // Large configurable tank for CRP and MKS liquids
+
+    MODEL
+    {
+        model = PlanetaryBaseInc/ContainerSystem/tank_rocketFuel
+    }
+
+    // --- general parameters ---
+    name = KKAOSS_MKS_Liquids_Tank
+    module = Part
+    author = Nils277/Grimmas
+
+    // --- asset parameters ---
+    scale = 1
+    rescaleFactor = 1
+
+    // --- node definitions ---
+    node_stack_top = 0, 0, 0, 1, 0, 0, 1
+    CoMOffset = -0.45, -0.45, 0.0
+
+    // --- editor parameters ---
+    TechRequired = experimentalScience
+    entryCost = 7000
+    cost = 2500
+    category = FuelTank
+    subcategory = 0
+    title = #LOC_KPBS.MKS.containerliquids.title
+    manufacturer = #LOC_KPBS.agency
+    description = #LOC_KPBS.MKS.containerliquids.description
+
+
+    // --- attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision ---
+    attachRules = 1,0,1,1,0
+
+
+    // --- standard part parameters ---
+    mass = 0.55
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 15
+    maxTemp = 2000 
+    bulkheadProfiles = Container
+    tags = #LOC_KPBS.MKS.containerliquids.tags
+    
+		// can participate in MKS logistics
+	MODULE:NEEDS[MKS]
+	{
+		name = USI_ModuleResourceWarehouse
+	}
+
+	// can be emptied in flight
+    //MODULE
+    //{
+    //    name = ModuleFuelJettison
+    //}
+	
+	// configurable storage
+	
+	MODULE
+    {
+        name = ModuleKerbetrotterResourceSwitch
+        setupGroup = Resources
+        availableInFlight = true
+        availableInEditor = true
+        replaceDefaultResources = false
+		switchingNeedsEmptyTank = true
+		allowToEmptyTank = true
+        resourceConfiguration = KERBETROTTER_LIQUID
+        resourceMultiplier = 0.32
+		evaOnly = true
+		requiredClass = Engineer
+    }
+
+	
+	// stock inventory support
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 150
+	}
+
+
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTankSmall.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTankSmall.cfg
@@ -1,0 +1,90 @@
+PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
+{
+    // Kerbal Space Program - Part Config
+    // Small configurable tank for CRP and MKS liquids
+
+    MODEL
+    {
+        model = PlanetaryBaseInc/ContainerSystem/tank_rocketFuel_small
+    }
+
+    // --- general parameters ---
+    name = KKAOSS_MKS_Small_Liquids_Tank
+    module = Part
+    author = Nils277/Grimmas
+
+    // --- asset parameters ---
+    scale = 1
+    rescaleFactor = 1
+
+    // --- node definitions ---
+    node_stack_top = 0, 0, 0, 1, 0, 0, 1
+    CoMOffset = -0.45, 0, 0
+    
+    // --- editor parameters ---
+    TechRequired = advScienceTech
+    entryCost = 4500
+    cost = 1300
+    category = FuelTank
+    subcategory = 0
+    title = #LOC_KPBS.MKS.containerliquidssmall.title
+    manufacturer = #LOC_KPBS.agency
+    description = #LOC_KPBS.MKS.containerliquidssmall.description
+
+
+    // --- attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision ---
+    attachRules = 1,0,1,1,0
+
+
+    // --- standard part parameters ---
+    mass = 0.3
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 15
+    maxTemp = 2000 
+    bulkheadProfiles = Container
+    tags = #LOC_KPBS.MKS.containerliquidssmall.tags
+    
+	
+	// can participate in MKS logistics
+	MODULE:NEEDS[MKS]
+	{
+		name = USI_ModuleResourceWarehouse
+	}
+
+	// can be emptied in flight
+    //MODULE
+    //{
+    //    name = ModuleFuelJettison
+    //}
+	
+	// configurable storage
+	
+	MODULE
+    {
+        name = ModuleKerbetrotterResourceSwitch
+        setupGroup = Resources
+        availableInFlight = true
+        availableInEditor = true
+        replaceDefaultResources = false
+		switchingNeedsEmptyTank = true
+		allowToEmptyTank = true
+        resourceConfiguration = KERBETROTTER_LIQUID
+        resourceMultiplier = 0.16
+		evaOnly = true
+		requiredClass = Engineer
+    }
+
+	
+	// stock inventory support
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 150
+	}
+
+    
+
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTankSmall.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/LiquidsTankSmall.cfg
@@ -53,12 +53,6 @@ PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
 	{
 		name = USI_ModuleResourceWarehouse
 	}
-
-	// can be emptied in flight
-    //MODULE
-    //{
-    //    name = ModuleFuelJettison
-    //}
 	
 	// configurable storage
 	

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTank.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTank.cfg
@@ -52,12 +52,6 @@ PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
 	{
 		name = USI_ModuleResourceWarehouse
 	}
-
-	// can be emptied in flight
-    //MODULE
-    //{
-    //    name = ModuleFuelJettison
-    //}
 	
 	// configurable storage
 	

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTank.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTank.cfg
@@ -1,0 +1,88 @@
+PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
+{
+    // Kerbal Space Program - Part Config
+    // Large configurable tank for CRP and MKS solids
+
+    MODEL
+    {
+        model = PlanetaryBaseInc/ContainerSystem/tank_ore
+    }
+
+    // --- general parameters ---
+    name = KKAOSS_MKS_Solids_Tank
+    module = Part
+    author = Nils277/Grimmas
+
+    // --- asset parameters ---
+    scale = 1
+    rescaleFactor = 1
+
+    // --- node definitions ---
+    node_stack_top = 0, 0, 0, 1, 0, 0, 1
+    CoMOffset = -0.45, -0.45, 0.0
+
+    // --- editor parameters ---
+    TechRequired = experimentalScience
+    entryCost = 7000
+    cost = 2500
+    category = FuelTank
+    subcategory = 0
+    title = #LOC_KPBS.MKS.containersolids.title
+    manufacturer = #LOC_KPBS.agency
+    description = #LOC_KPBS.MKS.containersolids.description
+
+
+    // --- attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision ---
+    attachRules = 1,0,1,1,0
+
+
+    // --- standard part parameters ---
+    mass = 0.55
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 15
+    maxTemp = 2000 // = 3000
+    bulkheadProfiles = Container
+    tags = #LOC_KPBS.MKS.containersolids.tags
+    
+		// can participate in MKS logistics
+	MODULE:NEEDS[MKS]
+	{
+		name = USI_ModuleResourceWarehouse
+	}
+
+	// can be emptied in flight
+    //MODULE
+    //{
+    //    name = ModuleFuelJettison
+    //}
+	
+	// configurable storage
+	
+	MODULE
+    {
+        name = ModuleKerbetrotterResourceSwitch
+        setupGroup = Resources
+        availableInFlight = true
+        availableInEditor = true
+        replaceDefaultResources = false
+		switchingNeedsEmptyTank = true
+		allowToEmptyTank = true
+        resourceConfiguration = KERBETROTTER_FREIGHT
+        resourceMultiplier = 0.32
+		evaOnly = true
+		requiredClass = Engineer
+    }
+
+	
+	// stock inventory support
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 150
+	}
+
+
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTankSmall.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTankSmall.cfg
@@ -1,0 +1,90 @@
+PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
+{
+    // Kerbal Space Program - Part Config
+    // Small configurable tank for CRP and MKS solids
+
+    MODEL
+    {
+        model = PlanetaryBaseInc/ContainerSystem/tank_ore_small
+    }
+
+    // --- general parameters ---
+    name = KKAOSS_MKS_Small_Solids_Tank
+    module = Part
+    author = Nils277/Grimmas
+
+    // --- asset parameters ---
+    scale = 1
+    rescaleFactor = 1
+
+    // --- node definitions ---
+    node_stack_top = 0, 0, 0, 1, 0, 0, 1
+    CoMOffset = -0.45, 0, 0
+    
+    // --- editor parameters ---
+    TechRequired = advScienceTech
+    entryCost = 4500
+    cost = 1300
+    category = FuelTank
+    subcategory = 0
+    title = #LOC_KPBS.MKS.containersolidssmall.title
+    manufacturer = #LOC_KPBS.agency
+    description = #LOC_KPBS.MKS.containersolidssmall.description
+
+
+    // --- attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision ---
+    attachRules = 1,0,1,1,0
+
+
+    // --- standard part parameters ---
+    mass = 0.3
+    dragModelType = default
+    maximum_drag = 0.2
+    minimum_drag = 0.2
+    angularDrag = 2
+    crashTolerance = 15
+    maxTemp = 2000 // = 3000
+    bulkheadProfiles = Container
+    tags = #LOC_KPBS.MKS.containersolidssmall.tags
+    
+	
+	// can participate in MKS logistics
+	MODULE:NEEDS[MKS]
+	{
+		name = USI_ModuleResourceWarehouse
+	}
+
+	// can be emptied in flight
+    //MODULE
+    //{
+    //    name = ModuleFuelJettison
+    //}
+	
+	// configurable storage
+	
+	MODULE
+    {
+        name = ModuleKerbetrotterResourceSwitch
+        setupGroup = Resources
+        availableInFlight = true
+        availableInEditor = true
+        replaceDefaultResources = false
+		switchingNeedsEmptyTank = true
+		allowToEmptyTank = true
+        resourceConfiguration = KERBETROTTER_FREIGHT
+        resourceMultiplier = 0.16
+		evaOnly = true
+		requiredClass = Engineer
+    }
+
+	
+	// stock inventory support
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 150
+	}
+
+    
+
+}

--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTankSmall.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Parts/MKS/SolidsTankSmall.cfg
@@ -53,12 +53,6 @@ PART:NEEDS[CommunityResourcePack&KerbetrotterTools]
 	{
 		name = USI_ModuleResourceWarehouse
 	}
-
-	// can be emptied in flight
-    //MODULE
-    //{
-    //    name = ModuleFuelJettison
-    //}
 	
 	// configurable storage
 	


### PR DESCRIPTION
Adding four switchable container wedges - regular and small containers for MKS solids and liquids.

They reuse the models from the ore and rocket fuel containers.

This relies on the other patch for FUR that I just submitted - https://github.com/Nils277/FelineUtilityRovers/pull/58

