### PR TITLE
Fix Kerbalism habitat configs.

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/KPBS_MM_Kerbalism_Habitation.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/KPBS_MM_Kerbalism_Habitation.cfg
@@ -1,5 +1,5 @@
 //-------------The Habitat MK2-----------------
-@PART[KKAOSS_Habitat_MK2_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Habitat_MK2_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -12,7 +12,7 @@
 }
 
 //-------------The Laboratory-----------------
-@PART[KKAOSS_Science_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Science_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -25,7 +25,7 @@
 }
 
 //-------------The Control Room-----------------
-@PART[KKAOSS_Control_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Control_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -35,7 +35,7 @@
 }
 
 //-------------The Cupola-----------------
-@PART[KKAOSS_Cupola_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Cupola_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -45,7 +45,7 @@
 }
 
 //-------------The Freezer-----------------
-@PART[CRY-5000Freezer]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[CRY-5000Freezer]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -55,7 +55,7 @@
 }
 
 //-------------The Habitat MK1-----------------
-@PART[KKAOSS_Habitat_MK1_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Habitat_MK1_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -65,7 +65,7 @@
 }
 
 //-------------The Central Hub-----------------
-@PART[KKAOSS_Central_Hub]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_Central_Hub]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -75,7 +75,7 @@
 }
 
 //-------------The Airlock-----------------
-@PART[KKAOSS_airlock_mid_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_airlock_mid_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -85,7 +85,7 @@
 }
 
 //-------------The Airlock End-----------------
-@PART[KKAOSS_airlock_end_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_airlock_end_g]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat]
 	{
@@ -94,7 +94,7 @@
 	}
 }
 //-------------The Corridors-----------------
-@PART[KKAOSS_corridor_6|KKAOSS_corridor_4|KKAOSS_corridor_6]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[Kerbalism]
+@PART[KKAOSS_corridor_6|KKAOSS_corridor_4|KKAOSS_corridor_6]:NEEDS[Kerbalism&FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	MODULE
 	{


### PR DESCRIPTION
At some point (possibly the Kerbalism 3 update?) it looks like the `AFTER` target got changed for these rules.  Without this change, all the habitats have default volumes and surface areas.  (The Mk2 planetary habitat suffers in particular, receiving only 2.62 m³ of volume when it should have 16.56 m³.)