### PR TITLE
Fix crop_rate (decimal typo) of KKAOSS_LS_container_greenhouse

### DIFF
--- a/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/Profiles/KPBS_MM_Kerbalism_Default.cfg
+++ b/FOR_RELEASE/GameData/PlanetaryBaseInc/ModSupport/Configs/Kerbalism/Profiles/KPBS_MM_Kerbalism_Default.cfg
@@ -213,7 +213,7 @@ RESOURCE_DEFINITION
 
         crop_resource = Food
         crop_size = 2.75625 // Approximately 1/10th of the volume of the normal greenhouse, so supports 0.05 Kerbal
-        crop_rate = 0.000000023148
+        crop_rate = 0.00000023148
         ec_rate = 0.5
 
         light_tolerance = 400.0


### PR DESCRIPTION
Decimal for crop_rate of Greenhouse container is misplaced (one too many zeroes), leading to a ridiculously useless harvest time